### PR TITLE
Fix license, skip recipe lookup for empty grids, don't render hidden signs

### DIFF
--- a/src/main/java/net/modfest/fireblanket/mixin/MixinRecipeManager.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/MixinRecipeManager.java
@@ -1,0 +1,57 @@
+package net.modfest.fireblanket.mixin;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.inventory.Inventory;
+import net.minecraft.recipe.RecipeManager;
+import net.minecraft.recipe.RecipeType;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.collection.DefaultedList;
+import net.minecraft.world.World;
+
+@Mixin(RecipeManager.class)
+public class MixinRecipeManager {
+
+	@Inject(at=@At("HEAD"), method={
+			"getFirstMatch(Lnet/minecraft/recipe/RecipeType;Lnet/minecraft/inventory/Inventory;Lnet/minecraft/world/World;)Ljava/util/Optional;"
+		}, cancellable=true)
+	public void fireblanket$getFirstMatch$DontScanEmptyGrids(RecipeType<?> type, Inventory inv, World world, CallbackInfoReturnable<Optional<?>> ci) {
+		if (inv != null && inv.isEmpty()) {
+			ci.setReturnValue(Optional.empty());
+		}
+	}
+
+	@Inject(at=@At("HEAD"), method={
+			"getFirstMatch(Lnet/minecraft/recipe/RecipeType;Lnet/minecraft/inventory/Inventory;Lnet/minecraft/world/World;Lnet/minecraft/util/Identifier;)Ljava/util/Optional;",
+		}, cancellable=true)
+	public void fireblanket$getFirstMatch$DontScanEmptyGrids(RecipeType<?> type, Inventory inv, World world, Identifier id, CallbackInfoReturnable<Optional<?>> ci) {
+		if (inv != null && inv.isEmpty()) {
+			ci.setReturnValue(Optional.empty());
+		}
+	}
+
+	@Inject(at=@At("HEAD"), method={
+			"getAllMatches(Lnet/minecraft/recipe/RecipeType;Lnet/minecraft/inventory/Inventory;Lnet/minecraft/world/World;)Ljava/util/List;",
+		}, cancellable=true)
+	public void fireblanket$getAllMatches$DontScanEmptyGrids(RecipeType<?> type, Inventory inv, World world, CallbackInfoReturnable<List<?>> ci) {
+		if (inv != null && inv.isEmpty()) {
+			ci.setReturnValue(List.of());
+		}
+	}
+
+	@Inject(at=@At("HEAD"), method={
+			"getRemainingStacks(Lnet/minecraft/recipe/RecipeType;Lnet/minecraft/inventory/Inventory;Lnet/minecraft/world/World;)Lnet/minecraft/util/collection/DefaultedList;"
+		}, cancellable=true)
+	public void fireblanket$getRemainingStacks$DontScanEmptyGrids(RecipeType<?> type, Inventory inv, World world, CallbackInfoReturnable<DefaultedList<?>> ci) {
+		if (inv != null && inv.isEmpty()) {
+			ci.setReturnValue(DefaultedList.of());
+		}
+	}
+	
+}

--- a/src/main/java/net/modfest/fireblanket/mixin/client/MixinSignBlockEntityRenderer.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/client/MixinSignBlockEntityRenderer.java
@@ -1,0 +1,22 @@
+package net.modfest.fireblanket.mixin.client;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.block.entity.SignBlockEntity;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.block.entity.SignBlockEntityRenderer;
+import net.minecraft.client.util.math.MatrixStack;
+
+// priority to dodge PictureSign
+@Mixin(value=SignBlockEntityRenderer.class, priority=5000)
+public class MixinSignBlockEntityRenderer {
+
+	@Inject(at=@At("HEAD"), method="render", cancellable=true)
+	public void fireblanket$DontRenderHiddenSigns(SignBlockEntity entity, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay, CallbackInfo ci) {
+		if (light == 0) ci.cancel();
+	}
+	
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -7,7 +7,7 @@
 	"authors": [
 		"Jasmine"
 	],
-	"license": "CC0-1.0",
+	"license": "MIT",
 	"icon": "assets/fireblanket/icon.png",
 	"environment": "*",
 	"entrypoints": {

--- a/src/main/resources/fireblanket.mixins.json
+++ b/src/main/resources/fireblanket.mixins.json
@@ -4,7 +4,8 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "MixinEntitySelector",
-    "MixinServerPlayerEntity"
+    "MixinServerPlayerEntity",
+    "MixinRecipeManager"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/fireblanket.mixins.json
+++ b/src/main/resources/fireblanket.mixins.json
@@ -13,6 +13,7 @@
   "client": [
     "client.MixinBlockEntityRenderDispatcher",
     "client.MixinRebuildTask",
-    "client.sodium.MixinChunkRenderRebuildTask"
+    "client.sodium.MixinChunkRenderRebuildTask",
+    "client.MixinSignBlockEntityRenderer"
   ]
 }


### PR DESCRIPTION
We don't want to full-on disable recipes again, so here's a fix for 95% of the lag.

Also does #1.