### PR TITLE
Write block entity nbt on networking thread instead of server one

### DIFF
--- a/src/main/java/net/modfest/fireblanket/mixin/MixinCustomPayloadS2CPacket.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/MixinCustomPayloadS2CPacket.java
@@ -1,0 +1,67 @@
+package net.modfest.fireblanket.mixin;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
+import net.minecraft.util.Identifier;
+import net.modfest.fireblanket.net.writer.CustomPayloadS2CExt;
+import net.modfest.fireblanket.net.writer.ServerPacketWriter;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+
+/**
+ * Main logic behind writing on net thread. See {@link ServerPacketWriter} for explanation
+ */
+@Mixin(CustomPayloadS2CPacket.class)
+public class MixinCustomPayloadS2CPacket implements CustomPayloadS2CExt {
+    @Shadow @Final private Identifier channel;
+    @Nullable
+    @Unique
+    private ServerPacketWriter writer;
+
+    @Override
+    public void fireblanket$setWriter(ServerPacketWriter packet) {
+        this.writer = packet;
+    }
+
+    @Inject(method = "write", at = @At("TAIL"))
+    private void fireblanket$write(PacketByteBuf buf, CallbackInfo ci) {
+        if (this.writer != null) {
+            this.writer.write(buf, this.channel);
+        }
+    }
+
+    /*
+    * This section is a bit of a "hack" to make sure it behaves more or less the same on singleplayer as on server.
+    * Battle tested in polymer™
+    */
+    @Environment(EnvType.CLIENT)
+    @ModifyArg(method = "getData", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketByteBuf;<init>(Lio/netty/buffer/ByteBuf;)V"))
+    private ByteBuf fireblanket$replaceEmpty(ByteBuf vanilla) {
+        if (this.writer != null) {
+            return Unpooled.buffer();
+        }
+        return vanilla;
+    }
+
+    @Environment(EnvType.CLIENT)
+    @Inject(method = "getData", at = @At("RETURN"))
+    private void fireblanket$writeData(CallbackInfoReturnable<PacketByteBuf> cir) {
+        if (this.writer != null) {
+            var buf = cir.getReturnValue();
+            this.writer.write(buf, this.channel);
+        }
+    }
+}

--- a/src/main/java/net/modfest/fireblanket/mixin/improved_be_sync/MixinChunkHolder.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/improved_be_sync/MixinChunkHolder.java
@@ -1,14 +1,12 @@
 package net.modfest.fireblanket.mixin.improved_be_sync;
 
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
-import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.nbt.NbtCompound;
-import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.listener.ClientPlayPacketListener;
 import net.minecraft.network.packet.Packet;
 import net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket;
-import net.minecraft.registry.Registries;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ChunkHolder;
 import net.minecraft.util.math.BlockPos;
@@ -105,7 +103,7 @@ public abstract class MixinChunkHolder {
                 return;
             }
 
-            var packet = new BundledBlockEntityUpdatePacket(BATCHED_UPDATES.toArray(new BEUpdate[0])).toPacket(Fireblanket.BATCHED_BE_UPDATE);
+            Packet<ClientPlayPacketListener> packet = new BundledBlockEntityUpdatePacket(BATCHED_UPDATES.toArray(new BEUpdate[0])).toPacket(Fireblanket.BATCHED_BE_UPDATE);
 
             for (ServerPlayerEntity p : list) {
                 p.networkHandler.sendPacket(packet);

--- a/src/main/java/net/modfest/fireblanket/net/BundledBlockEntityUpdatePacket.java
+++ b/src/main/java/net/modfest/fireblanket/net/BundledBlockEntityUpdatePacket.java
@@ -10,7 +10,7 @@ public record BundledBlockEntityUpdatePacket(BEUpdate[] updates) implements Serv
 
     @Override
     public void write(PacketByteBuf buf, Identifier packetId) {
-        var size = updates.length;
+        int size = updates.length;
         buf.writeVarInt(size);
         for (int i = 0; i < size; i++) {
             BEUpdate bup = updates[i];

--- a/src/main/java/net/modfest/fireblanket/net/BundledBlockEntityUpdatePacket.java
+++ b/src/main/java/net/modfest/fireblanket/net/BundledBlockEntityUpdatePacket.java
@@ -1,0 +1,22 @@
+package net.modfest.fireblanket.net;
+
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.registry.Registries;
+import net.minecraft.util.Identifier;
+import net.modfest.fireblanket.net.writer.ServerPacketWriter;
+
+
+public record BundledBlockEntityUpdatePacket(BEUpdate[] updates) implements ServerPacketWriter {
+
+    @Override
+    public void write(PacketByteBuf buf, Identifier packetId) {
+        var size = updates.length;
+        buf.writeVarInt(size);
+        for (int i = 0; i < size; i++) {
+            BEUpdate bup = updates[i];
+            buf.writeBlockPos(bup.pos());
+            buf.writeRegistryValue(Registries.BLOCK_ENTITY_TYPE, bup.type());
+            buf.writeNbt(bup.nbt());
+        }
+    }
+}

--- a/src/main/java/net/modfest/fireblanket/net/writer/CustomPayloadS2CExt.java
+++ b/src/main/java/net/modfest/fireblanket/net/writer/CustomPayloadS2CExt.java
@@ -1,0 +1,5 @@
+package net.modfest.fireblanket.net.writer;
+
+public interface CustomPayloadS2CExt {
+    void fireblanket$setWriter(ServerPacketWriter packet);
+}

--- a/src/main/java/net/modfest/fireblanket/net/writer/ServerPacketWriter.java
+++ b/src/main/java/net/modfest/fireblanket/net/writer/ServerPacketWriter.java
@@ -14,15 +14,18 @@ import net.minecraft.util.Identifier;
  *
  * This is a (minimally) simplified version of interface from Polymer Networking API.
  * In case of bigger data (like polymer's registry sync), performance increase was noticeable,
- * so I thought it would be good idea to bring it here.
+ * making it a good choice for possibly data heavy packets.
+ * Additionally, it keeps player context while writing the packet.
  *
- * Vanilla adopted similar (through bit fancier) approach with it's own CustomPayload packets in 1.20.2 (23w31a)
+ * Vanilla adopted similar (through bit fancier) approach with its own CustomPayload packets in 1.20.2 (23w31a)
+ *
+ * @author Patbox
  */
 public interface ServerPacketWriter {
     void write(PacketByteBuf buf, Identifier packetId);
 
     default Packet<ClientPlayPacketListener> toPacket(Identifier identifier) {
-        var base = new CustomPayloadS2CPacket(identifier, new PacketByteBuf(Unpooled.EMPTY_BUFFER));
+        CustomPayloadS2CPacket base = new CustomPayloadS2CPacket(identifier, new PacketByteBuf(Unpooled.EMPTY_BUFFER));
         ((CustomPayloadS2CExt) base).fireblanket$setWriter(this);
         return base;
     }

--- a/src/main/java/net/modfest/fireblanket/net/writer/ServerPacketWriter.java
+++ b/src/main/java/net/modfest/fireblanket/net/writer/ServerPacketWriter.java
@@ -1,0 +1,29 @@
+package net.modfest.fireblanket.net.writer;
+
+import io.netty.buffer.Unpooled;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.listener.ClientPlayPacketListener;
+import net.minecraft.network.packet.Packet;
+import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
+import net.minecraft.util.Identifier;
+
+
+/**
+ * ServerPacketWriter is a utility method for creating CustomPayloadS2CPackets that write on network thread
+ * instead of server one.
+ *
+ * This is a (minimally) simplified version of interface from Polymer Networking API.
+ * In case of bigger data (like polymer's registry sync), performance increase was noticeable,
+ * so I thought it would be good idea to bring it here.
+ *
+ * Vanilla adopted similar (through bit fancier) approach with it's own CustomPayload packets in 1.20.2 (23w31a)
+ */
+public interface ServerPacketWriter {
+    void write(PacketByteBuf buf, Identifier packetId);
+
+    default Packet<ClientPlayPacketListener> toPacket(Identifier identifier) {
+        var base = new CustomPayloadS2CPacket(identifier, new PacketByteBuf(Unpooled.EMPTY_BUFFER));
+        ((CustomPayloadS2CExt) base).fireblanket$setWriter(this);
+        return base;
+    }
+}

--- a/src/main/resources/fireblanket.mixins.json
+++ b/src/main/resources/fireblanket.mixins.json
@@ -3,6 +3,7 @@
   "package": "net.modfest.fireblanket.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "MixinCustomPayloadS2CPacket",
     "MixinEntitySelector",
     "MixinRecipeManager",
     "MixinServerPlayerEntity",


### PR DESCRIPTION
This pr adds ServerPacketWriter, a utility interface for creation on CustomPayloadS2CPackets that write on networking thread. The implementation is lifted directly with polymer with few simplifications, since you don't need player context or packet version handling.

From my testing (within polymer) it indeed is faster (with most noticeable effect with large, nbt driven packets).

Ran this in singleplayer and all methods wrote and read data correctly