### PR TITLE
Add blame for bad render calls, allow enabling BE masking with a sysprop

### DIFF
--- a/src/main/java/net/modfest/fireblanket/FireblanketClient.java
+++ b/src/main/java/net/modfest/fireblanket/FireblanketClient.java
@@ -14,7 +14,7 @@ import net.modfest.fireblanket.client.command.BERMaskCommand;
 public class FireblanketClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
-        if (GlobalFlags.DO_BE_MASKING) {
+        if (FireblanketMixin.DO_BE_MASKING) {
             BERMaskCommand.init();
         }
 

--- a/src/main/java/net/modfest/fireblanket/FireblanketMixin.java
+++ b/src/main/java/net/modfest/fireblanket/FireblanketMixin.java
@@ -1,0 +1,51 @@
+package net.modfest.fireblanket;
+
+import java.util.List;
+import java.util.Set;
+
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+public class FireblanketMixin implements IMixinConfigPlugin {
+
+	public static final boolean DO_BE_MASKING = Boolean.getBoolean("fireblanket.beMasking");
+
+	@Override
+	public void onLoad(String mixinPackage) {
+		
+	}
+
+	@Override
+	public String getRefMapperConfig() {
+		return null;
+	}
+
+	@Override
+	public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+		if (mixinClassName.contains("be_masking")) {
+			return DO_BE_MASKING;
+		}
+		return true;
+	}
+
+	@Override
+	public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+	}
+
+	@Override
+	public List<String> getMixins() {
+		return List.of();
+	}
+
+	@Override
+	public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+		
+	}
+
+	@Override
+	public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+		
+	}
+
+}

--- a/src/main/java/net/modfest/fireblanket/GlobalFlags.java
+++ b/src/main/java/net/modfest/fireblanket/GlobalFlags.java
@@ -1,5 +1,0 @@
-package net.modfest.fireblanket;
-
-public class GlobalFlags {
-    public static final boolean DO_BE_MASKING = false;
-}

--- a/src/main/java/net/modfest/fireblanket/client/BlamefulRenderCall.java
+++ b/src/main/java/net/modfest/fireblanket/client/BlamefulRenderCall.java
@@ -1,0 +1,25 @@
+package net.modfest.fireblanket.client;
+
+import com.mojang.blaze3d.systems.RenderCall;
+
+public class BlamefulRenderCall implements RenderCall {
+
+	private final RenderCall delegate;
+	private final Throwable stacktrace;
+	
+	public BlamefulRenderCall(RenderCall delegate) {
+		this.delegate = delegate;
+		this.stacktrace = new Throwable("Created here in thread "+Thread.currentThread().getName());
+	}
+	
+	@Override
+	public void execute() {
+		try {
+			delegate.execute();
+		} catch (Error | RuntimeException e) {
+			e.addSuppressed(stacktrace);
+			throw e;
+		}
+	}
+	
+}

--- a/src/main/java/net/modfest/fireblanket/mixin/client/MixinRenderSystem.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/client/MixinRenderSystem.java
@@ -1,0 +1,33 @@
+package net.modfest.fireblanket.mixin.client;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import com.mojang.blaze3d.systems.RenderCall;
+import com.mojang.blaze3d.systems.RenderSystem;
+
+import net.modfest.fireblanket.Fireblanket;
+import net.modfest.fireblanket.client.BlamefulRenderCall;
+
+@Mixin(RenderSystem.class)
+public class MixinRenderSystem {
+
+	@Shadow @Final
+	private static ConcurrentLinkedQueue<RenderCall> recordingQueue;
+	
+	/**
+	 * @author unascribed
+	 * @reason Add blame and log when dubious things occur
+	 */
+	@Overwrite
+	public static void recordRenderCall(RenderCall renderCall) {
+		if (!RenderSystem.isOnRenderThread()) {
+			Fireblanket.LOGGER.warn("A render call was made off the render thread! This is likely to lead to race conditions!", new Throwable());
+		}
+		recordingQueue.add(new BlamefulRenderCall(renderCall));
+	}
+	
+}

--- a/src/main/java/net/modfest/fireblanket/mixin/client/be_masking/MixinBlockEntityRenderDispatcher.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/client/be_masking/MixinBlockEntityRenderDispatcher.java
@@ -1,14 +1,11 @@
-package net.modfest.fireblanket.mixin.client;
+package net.modfest.fireblanket.mixin.client.be_masking;
 
 import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
-import net.minecraft.client.render.block.entity.BlockEntityRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.registry.Registries;
-import net.modfest.fireblanket.GlobalFlags;
 import net.modfest.fireblanket.client.ClientState;
 import net.modfest.fireblanket.client.render.QuadEmitter;
 import net.modfest.fireblanket.client.render.RenderLayers;
@@ -21,16 +18,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class MixinBlockEntityRenderDispatcher {
     @Inject(method = "render(Lnet/minecraft/block/entity/BlockEntity;FLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;)V", at = @At("HEAD"))
     private <T extends BlockEntity> void fireblanket$renderMaskedEntities(T blockEntity, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, CallbackInfo ci) {
-        if (GlobalFlags.DO_BE_MASKING) { // At con time, this will be set to false and javac will strip out the code at build time
-            if (ClientState.MASKED_BERS.contains(Registries.BLOCK_ENTITY_TYPE.getId(blockEntity.getType()))) {
-                VertexConsumer buffer = vertexConsumers.getBuffer(RenderLayers.TRANSLUCENT_BROKEN_DEPTH);
+        if (ClientState.MASKED_BERS.contains(Registries.BLOCK_ENTITY_TYPE.getId(blockEntity.getType()))) {
+            VertexConsumer buffer = vertexConsumers.getBuffer(RenderLayers.TRANSLUCENT_BROKEN_DEPTH);
 
-                QuadEmitter.buildBox(buffer, matrices, 0, 1.00001f, 0, 1.00001f, 0, 1.00001f, 30, 200, 220, 40);
+            QuadEmitter.buildBox(buffer, matrices, 0, 1.00001f, 0, 1.00001f, 0, 1.00001f, 30, 200, 220, 40);
 
-                // Please let this be a normal field trip
-                if (vertexConsumers instanceof VertexConsumerProvider.Immediate imm) {
-                    imm.draw();
-                }
+            // Please let this be a normal field trip
+            if (vertexConsumers instanceof VertexConsumerProvider.Immediate imm) {
+                imm.draw();
             }
         }
     }

--- a/src/main/java/net/modfest/fireblanket/mixin/client/be_masking/MixinRebuildTask.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/client/be_masking/MixinRebuildTask.java
@@ -1,10 +1,9 @@
-package net.modfest.fireblanket.mixin.client;
+package net.modfest.fireblanket.mixin.client.be_masking;
 
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.block.entity.BlockEntityRenderer;
 import net.minecraft.client.render.chunk.ChunkBuilder;
-import net.modfest.fireblanket.GlobalFlags;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -14,10 +13,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class MixinRebuildTask {
     @Inject(method = "addBlockEntity", at = @At("TAIL"))
     private <E extends BlockEntity> void fireblanket$addBEAnyway(ChunkBuilder.BuiltChunk.RebuildTask.RenderData renderData, E blockEntity, CallbackInfo ci) {
-        if (GlobalFlags.DO_BE_MASKING) {
-            if (!renderData.blockEntities.contains(blockEntity)) {
-                renderData.blockEntities.add(blockEntity);
-            }
+        if (!renderData.blockEntities.contains(blockEntity)) {
+            renderData.blockEntities.add(blockEntity);
         }
     }
 }

--- a/src/main/java/net/modfest/fireblanket/mixin/client/be_masking/sodium/MixinChunkRenderRebuildTask.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/client/be_masking/sodium/MixinChunkRenderRebuildTask.java
@@ -1,4 +1,4 @@
-package net.modfest.fireblanket.mixin.client.sodium;
+package net.modfest.fireblanket.mixin.client.be_masking.sodium;
 
 import me.jellysquid.mods.sodium.client.gl.compile.ChunkBuildContext;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuildBuffers;
@@ -15,7 +15,6 @@ import net.minecraft.client.render.block.entity.BlockEntityRenderer;
 import net.minecraft.client.render.chunk.ChunkOcclusionDataBuilder;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.util.math.BlockPos;
-import net.modfest.fireblanket.GlobalFlags;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
@@ -28,10 +27,8 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 public class MixinChunkRenderRebuildTask {
     @Inject(method = "performBuild", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/client/render/block/entity/BlockEntityRenderDispatcher;get(Lnet/minecraft/block/entity/BlockEntity;)Lnet/minecraft/client/render/block/entity/BlockEntityRenderer;", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)
     private void fireblanket$AddBEAnyway_Sodium(ChunkBuildContext buildContext, CancellationSource cancellationSource, CallbackInfoReturnable<ChunkBuildResult> cir, ChunkRenderData.Builder renderData, ChunkOcclusionDataBuilder occluder, ChunkRenderBounds.Builder bounds, ChunkBuildBuffers buffers, BlockRenderCache cache, WorldSlice slice, int minX, int minY, int minZ, int maxX, int maxY, int maxZ, BlockPos.Mutable blockPos, BlockPos.Mutable modelOffset, BlockRenderContext context, int y, int z, int x, BlockState blockState, boolean rendered, FluidState fluidState, BlockEntity entity, BlockEntityRenderer renderer) {
-        if (GlobalFlags.DO_BE_MASKING) {
-            if (renderer == null) {
-                renderData.addBlockEntity(entity, false);
-            }
+        if (renderer == null) {
+            renderData.addBlockEntity(entity, false);
         }
     }
 }

--- a/src/main/resources/fireblanket.mixins.json
+++ b/src/main/resources/fireblanket.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "net.modfest.fireblanket.mixin",
   "compatibilityLevel": "JAVA_17",
+  "plugin": "net.modfest.fireblanket.FireblanketMixin",
   "mixins": [
     "EntityTypeAccessor",
     "MixinEntitySelector",
@@ -16,9 +17,10 @@
     "defaultRequire": 1
   },
   "client": [
-    "client.MixinBlockEntityRenderDispatcher",
-    "client.MixinRebuildTask",
+    "client.be_masking.MixinBlockEntityRenderDispatcher",
+    "client.be_masking.MixinRebuildTask",
+    "client.be_masking.sodium.MixinChunkRenderRebuildTask",
     "client.MixinSignBlockEntityRenderer",
-    "client.sodium.MixinChunkRenderRebuildTask"
+    "client.MixinRenderSystem"
   ]
 }


### PR DESCRIPTION
Added blame for bad render calls to debug a mysterious NativeImage NPE crash. The creation of the stack trace looks expensive, but deferred render calls like this are rare and almost always caused by a buggy mod — their only legitimate use is during initialization, at which point the performance loss from making the stacktrace is negligible.

Also added a mixin plugin — makes the BE masking mixins not apply at all unless `-Dfireblanket.beMasking=true` is passed. This also allows enabling it for debugging without recompiling the mod.