### PR TITLE
Carmot Shield syncing fix, add async packet sending, add chunk packet caching, io_uring, zstd full-stream compression

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,11 @@ repositories {
 			includeGroup "maven.modrinth"
 		}
 	}
+	mavenCentral()
+}
+
+configurations {
+	shade
 }
 
 dependencies {
@@ -34,6 +39,14 @@ dependencies {
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	modCompileOnly "maven.modrinth:sodium:mc1.20-0.4.10"
+	
+	modImplementation "io.netty.incubator:netty-incubator-transport-classes-io_uring:0.0.15.Final"
+	modImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:0.0.15.Final:linux-x86_64"
+	modImplementation "com.github.luben:zstd-jni:1.5.5-5"
+	
+	shade("io.netty.incubator:netty-incubator-transport-classes-io_uring:0.0.15.Final") { transitive = false }
+	shade("io.netty.incubator:netty-incubator-transport-native-io_uring:0.0.15.Final:linux-x86_64") { transitive = false }
+	shade("com.github.luben:zstd-jni:1.5.5-5") { transitive = false }
 	
 	// Uncomment the following line to enable the deprecated Fabric API modules. 
 	// These are included in the Fabric API production distribution and allow you to update your mod to the latest modules at a later more convenient time.
@@ -76,6 +89,12 @@ java {
 jar {
 	from("LICENSE") {
 		rename { "${it}_${project.base.archivesName.get()}"}
+	}
+	
+	configurations.shade.resolve().each {
+		from(zipTree(it)) {
+			exclude 'META-INF/**'
+		}
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,16 @@ tasks.withType(JavaCompile).configureEach {
 	it.options.release = 17
 }
 
+sourceSets {
+	dummy {
+		compileClasspath += sourceSets.main.compileClasspath
+	}
+	main {
+		compileClasspath += sourceSets.dummy.output
+	}
+}
+
+
 java {
 	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
 	// if it is present.

--- a/src/dummy/java/dev/onyxstudios/cca/api/v3/component/ComponentKey.java
+++ b/src/dummy/java/dev/onyxstudios/cca/api/v3/component/ComponentKey.java
@@ -1,0 +1,7 @@
+package dev.onyxstudios.cca.api.v3.component;
+
+public abstract class ComponentKey {
+
+    public abstract void sync(Object provider);
+
+}

--- a/src/dummy/java/io/github/theepicblock/polymc/api/PolyMap.java
+++ b/src/dummy/java/io/github/theepicblock/polymc/api/PolyMap.java
@@ -1,0 +1,5 @@
+package io.github.theepicblock.polymc.api;
+
+public interface PolyMap {
+    boolean isVanillaLikeMap();
+}

--- a/src/dummy/java/io/github/theepicblock/polymc/impl/Util.java
+++ b/src/dummy/java/io/github/theepicblock/polymc/impl/Util.java
@@ -1,0 +1,13 @@
+package io.github.theepicblock.polymc.impl;
+
+import io.github.theepicblock.polymc.api.PolyMap;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+
+public class Util {
+
+    public static PolyMap tryGetPolyMap(ServerPlayerEntity player) {
+        throw new AbstractMethodError("Stub!");
+    }
+
+}

--- a/src/dummy/java/io/github/theepicblock/polymc/impl/mixin/ChunkPacketStaticHack.java
+++ b/src/dummy/java/io/github/theepicblock/polymc/impl/mixin/ChunkPacketStaticHack.java
@@ -1,0 +1,7 @@
+package io.github.theepicblock.polymc.impl.mixin;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+
+public class ChunkPacketStaticHack {
+    public static ThreadLocal<ServerPlayerEntity> player = new ThreadLocal<>();
+}

--- a/src/main/java/net/modfest/fireblanket/Fireblanket.java
+++ b/src/main/java/net/modfest/fireblanket/Fireblanket.java
@@ -4,12 +4,16 @@ import net.fabricmc.api.ModInitializer;
 
 import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.network.ClientConnection;
+import net.minecraft.network.PacketCallbacks;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.block.Block;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
 import net.modfest.fireblanket.command.DumpCommandBlocksCommand;
 import net.modfest.fireblanket.command.DumpEntityTypesCommand;
+import net.modfest.fireblanket.mixin.ClientConnectionAccessor;
 import net.modfest.fireblanket.world.blocks.UpdateSignBlockEntityTypes;
 import net.modfest.fireblanket.world.entity.EntityFilters;
 import org.slf4j.Logger;
@@ -18,12 +22,18 @@ import org.slf4j.LoggerFactory;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class Fireblanket implements ModInitializer {
 	public static final Identifier BATCHED_BE_UPDATE = new Identifier("fireblanket", "batched_be_sync");
     public static final Logger LOGGER = LoggerFactory.getLogger("Fireblanket");
     
-    public static final LinkedBlockingQueue<Runnable> PACKET_QUEUE = new LinkedBlockingQueue<>();
+    public record QueuedPacket(ClientConnection conn, Packet<?> packet, PacketCallbacks listener) {}
+    
+    private static final AtomicInteger nextQueue = new AtomicInteger();
+    
+    @SuppressWarnings("unchecked")
+	public static final LinkedBlockingQueue<QueuedPacket>[] PACKET_QUEUES = new LinkedBlockingQueue[4];
 
 	@Override
 	public void onInitialize() {
@@ -47,16 +57,25 @@ public class Fireblanket implements ModInitializer {
 			}
 		}
 		
-		Thread packetThread = new Thread(() -> {
-			while (true) {
-				try {
-					PACKET_QUEUE.take().run();
-				} catch (Throwable t) {
-					LOGGER.error("Exception in packet thread", t);
+		for (int i = 0; i < PACKET_QUEUES.length; i++) {
+			LinkedBlockingQueue<QueuedPacket> q = new LinkedBlockingQueue<>();
+			PACKET_QUEUES[i] = q;
+			Thread thread = new Thread(() -> {
+				while (true) {
+					try {
+						QueuedPacket p = q.take();
+						((ClientConnectionAccessor)p.conn()).fireblanket$sendImmediately(p.packet(), p.listener());
+					} catch (Throwable t) {
+						LOGGER.error("Exception in packet thread", t);
+					}
 				}
-			}
-		}, "Fireblanket async packet send thread");
-		packetThread.setDaemon(true);
-		packetThread.start();
+			}, "Fireblanket async packet send thread #"+(i+1));
+			thread.setDaemon(true);
+			thread.start();
+		}
+	}
+
+	public static LinkedBlockingQueue<QueuedPacket> getNextQueue() {
+		return PACKET_QUEUES[Math.floorMod(nextQueue.getAndIncrement(), PACKET_QUEUES.length)];
 	}
 }

--- a/src/main/java/net/modfest/fireblanket/Fireblanket.java
+++ b/src/main/java/net/modfest/fireblanket/Fireblanket.java
@@ -3,21 +3,29 @@ package net.modfest.fireblanket;
 import net.fabricmc.api.ModInitializer;
 
 import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.fabricmc.fabric.api.networking.v1.ServerLoginConnectionEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerLoginNetworking;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.network.PacketCallbacks;
 import net.minecraft.network.packet.Packet;
 import net.minecraft.block.Block;
 import net.minecraft.registry.Registries;
-import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
 import net.modfest.fireblanket.command.DumpCommandBlocksCommand;
 import net.modfest.fireblanket.command.DumpEntityTypesCommand;
+import net.modfest.fireblanket.compat.PolyMcCompat;
 import net.modfest.fireblanket.mixin.ClientConnectionAccessor;
 import net.modfest.fireblanket.world.blocks.UpdateSignBlockEntityTypes;
+import net.modfest.fireblanket.mixin.ServerLoginNetworkHandlerAccessor;
+import net.modfest.fireblanket.mixinsupport.FSCConnection;
 import net.modfest.fireblanket.world.entity.EntityFilters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.github.luben.zstd.util.Native;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,6 +34,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class Fireblanket implements ModInitializer {
 	public static final Identifier BATCHED_BE_UPDATE = new Identifier("fireblanket", "batched_be_sync");
+    public static final Identifier FULL_STREAM_COMPRESSION = new Identifier("fireblanket", "full_stream_compression");
+	
     public static final Logger LOGGER = LoggerFactory.getLogger("Fireblanket");
     
     public record QueuedPacket(ClientConnection conn, Packet<?> packet, PacketCallbacks listener) {}
@@ -34,7 +44,9 @@ public class Fireblanket implements ModInitializer {
     
     @SuppressWarnings("unchecked")
 	public static final LinkedBlockingQueue<QueuedPacket>[] PACKET_QUEUES = new LinkedBlockingQueue[4];
-
+    
+    public static boolean CAN_USE_ZSTD = false;
+    
 	@Override
 	public void onInitialize() {
 		DumpCommandBlocksCommand.init();
@@ -72,6 +84,32 @@ public class Fireblanket implements ModInitializer {
 			}, "Fireblanket async packet send thread #"+(i+1));
 			thread.setDaemon(true);
 			thread.start();
+		}
+		
+		try {
+		    Native.load();
+		    CAN_USE_ZSTD = true;
+		} catch (UnsatisfiedLinkError e) {
+		    CAN_USE_ZSTD = false;
+		    LOGGER.warn("Could not load zstd, full-stream compression unavailable", e);
+		}
+		
+		if (CAN_USE_ZSTD) {
+            LOGGER.info("Enabling full-stream compression");
+		    ServerLoginConnectionEvents.QUERY_START.addPhaseOrdering(new Identifier("fireblanket:pre"), Event.DEFAULT_PHASE);
+    		ServerLoginConnectionEvents.QUERY_START.register(new Identifier("fireblanket:pre"), (handler, server, sender, synchronizer) -> {
+    		    sender.sendPacket(FULL_STREAM_COMPRESSION, PacketByteBufs.empty());
+    		});
+		}
+		
+		ServerLoginNetworking.registerGlobalReceiver(FULL_STREAM_COMPRESSION, (server, handler, understood, buf, synchronizer, responseSender) -> {
+		    if (understood) {
+		        ((FSCConnection)((ServerLoginNetworkHandlerAccessor)handler).fireblanket$getConnection()).fireblanket$enableFullStreamCompression();
+		    }
+		});
+		
+		if (FabricLoader.getInstance().isModLoaded("polymc")) {
+		    PolyMcCompat.init();
 		}
 	}
 

--- a/src/main/java/net/modfest/fireblanket/FireblanketClient.java
+++ b/src/main/java/net/modfest/fireblanket/FireblanketClient.java
@@ -1,16 +1,32 @@
 package net.modfest.fireblanket;
 
+import java.util.concurrent.CompletableFuture;
+
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.networking.v1.ClientLoginNetworking;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket;
 import net.modfest.fireblanket.client.command.BERMaskCommand;
+import net.modfest.fireblanket.mixin.ClientLoginNetworkHandlerAccessor;
+import net.modfest.fireblanket.mixinsupport.FSCConnection;
 
 public class FireblanketClient implements ClientModInitializer {
+    
     @Override
     public void onInitializeClient() {
         if (FireblanketMixin.DO_BE_MASKING) {
             BERMaskCommand.init();
         }
+
+        ClientLoginNetworking.registerGlobalReceiver(Fireblanket.FULL_STREAM_COMPRESSION, (client, handler, buf, listenerAdder) -> {
+            if (Fireblanket.CAN_USE_ZSTD) {
+                ((FSCConnection)((ClientLoginNetworkHandlerAccessor)handler).fireblanket$getConnection()).fireblanket$enableFullStreamCompression();
+                return CompletableFuture.completedFuture(PacketByteBufs.empty());
+            } else {
+                return CompletableFuture.completedFuture(null);
+            }
+        });
 
         ClientPlayNetworking.registerGlobalReceiver(Fireblanket.BATCHED_BE_UPDATE, (client, handler, buf, sender) -> {
             int size = buf.readVarInt();

--- a/src/main/java/net/modfest/fireblanket/PolyMcAccess.java
+++ b/src/main/java/net/modfest/fireblanket/PolyMcAccess.java
@@ -1,0 +1,13 @@
+package net.modfest.fireblanket;
+
+import java.util.function.BooleanSupplier;
+
+public class PolyMcAccess {
+
+    public static BooleanSupplier isActive = () -> false;
+    
+    public static boolean isActive() {
+        return isActive.getAsBoolean();
+    }
+    
+}

--- a/src/main/java/net/modfest/fireblanket/ReassignableInputStream.java
+++ b/src/main/java/net/modfest/fireblanket/ReassignableInputStream.java
@@ -1,0 +1,61 @@
+package net.modfest.fireblanket;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class ReassignableInputStream extends InputStream {
+
+    private InputStream delegate;
+    
+    public void setDelegate(InputStream delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public int read() throws IOException {
+        return delegate.read();
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        return delegate.read(b, off, len);
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        return delegate.skip(n);
+    }
+
+    @Override
+    public int available() throws IOException {
+        return delegate.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+
+    @Override
+    public void mark(int readlimit) {
+        delegate.mark(readlimit);
+    }
+
+    @Override
+    public void reset() throws IOException {
+        delegate.reset();
+    }
+
+    @Override
+    public boolean markSupported() {
+        return delegate.markSupported();
+    }
+
+    @Override
+    public long transferTo(OutputStream out) throws IOException {
+        return delegate.transferTo(out);
+    }
+    
+
+}

--- a/src/main/java/net/modfest/fireblanket/ReassignableOutputStream.java
+++ b/src/main/java/net/modfest/fireblanket/ReassignableOutputStream.java
@@ -1,0 +1,34 @@
+package net.modfest.fireblanket;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class ReassignableOutputStream extends OutputStream {
+
+    private OutputStream delegate;
+    
+    public void setDelegate(OutputStream delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        delegate.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        delegate.write(b, off, len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        delegate.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+    
+}

--- a/src/main/java/net/modfest/fireblanket/compat/PolyMcCompat.java
+++ b/src/main/java/net/modfest/fireblanket/compat/PolyMcCompat.java
@@ -1,0 +1,17 @@
+package net.modfest.fireblanket.compat;
+
+import io.github.theepicblock.polymc.impl.Util;
+import io.github.theepicblock.polymc.impl.mixin.ChunkPacketStaticHack;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.modfest.fireblanket.PolyMcAccess;
+
+public class PolyMcCompat {
+
+    public static void init() {
+        PolyMcAccess.isActive = () -> {
+            ServerPlayerEntity polyPlayer = ChunkPacketStaticHack.player.get();
+            return polyPlayer != null && Util.tryGetPolyMap(polyPlayer).isVanillaLikeMap();
+        };
+    }
+    
+}

--- a/src/main/java/net/modfest/fireblanket/mixin/ClientConnectionAccessor.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/ClientConnectionAccessor.java
@@ -1,0 +1,16 @@
+package net.modfest.fireblanket.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import net.minecraft.network.ClientConnection;
+import net.minecraft.network.PacketCallbacks;
+import net.minecraft.network.packet.Packet;
+
+@Mixin(ClientConnection.class)
+public interface ClientConnectionAccessor {
+
+	@Invoker("sendImmediately")
+	void fireblanket$sendImmediately(Packet<?> packet, PacketCallbacks callbacks);
+	
+}

--- a/src/main/java/net/modfest/fireblanket/mixin/ClientConnectionAccessor.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/ClientConnectionAccessor.java
@@ -1,8 +1,10 @@
 package net.modfest.fireblanket.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.gen.Invoker;
 
+import io.netty.channel.Channel;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.network.PacketCallbacks;
 import net.minecraft.network.packet.Packet;
@@ -12,5 +14,8 @@ public interface ClientConnectionAccessor {
 
 	@Invoker("sendImmediately")
 	void fireblanket$sendImmediately(Packet<?> packet, PacketCallbacks callbacks);
+	
+	@Accessor("channel")
+	Channel fireblanket$getChannel();
 	
 }

--- a/src/main/java/net/modfest/fireblanket/mixin/ClientLoginNetworkHandlerAccessor.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/ClientLoginNetworkHandlerAccessor.java
@@ -1,0 +1,15 @@
+package net.modfest.fireblanket.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.client.network.ClientLoginNetworkHandler;
+import net.minecraft.network.ClientConnection;
+
+@Mixin(ClientLoginNetworkHandler.class)
+public interface ClientLoginNetworkHandlerAccessor {
+
+    @Accessor("connection")
+    ClientConnection fireblanket$getConnection();
+    
+}

--- a/src/main/java/net/modfest/fireblanket/mixin/MixinClientConnection.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/MixinClientConnection.java
@@ -1,22 +1,48 @@
 package net.modfest.fireblanket.mixin;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.github.luben.zstd.ZstdInputStream;
+import com.github.luben.zstd.ZstdOutputStream;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelPipeline;
 import net.minecraft.network.ClientConnection;
+import net.minecraft.network.NetworkState;
 import net.minecraft.network.PacketCallbacks;
 import net.minecraft.network.packet.Packet;
+import net.minecraft.network.packet.s2c.play.GameJoinS2CPacket;
 import net.modfest.fireblanket.Fireblanket;
+import net.modfest.fireblanket.ReassignableOutputStream;
 import net.modfest.fireblanket.Fireblanket.QueuedPacket;
+import net.modfest.fireblanket.ReassignableInputStream;
+import net.modfest.fireblanket.mixinsupport.FSCConnection;
+import net.modfest.fireblanket.net.ZstdDecoder;
+import net.modfest.fireblanket.net.ZstdEncoder;
 
 @Mixin(ClientConnection.class)
-public class MixinClientConnection {
+public class MixinClientConnection implements FSCConnection {
 
+    @Shadow
+    private Channel channel;
+    
+    @Shadow
+    private void sendImmediately(Packet<?> packet, PacketCallbacks callbacks) { throw new AbstractMethodError(); }
+    @Shadow
+    public boolean isEncrypted() { throw new AbstractMethodError(); }
+    
 	private final LinkedBlockingQueue<QueuedPacket> fireblanket$queue = Fireblanket.getNextQueue();
+	private boolean fireblanket$fsc = false;
+	private boolean fireblanket$fscStarted = false;
 	
 	/**
 	 * With a lot of connections, simply the act of writing packets becomes slow.
@@ -28,7 +54,60 @@ public class MixinClientConnection {
 	@Redirect(at=@At(value="INVOKE", target="net/minecraft/network/ClientConnection.sendImmediately(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/PacketCallbacks;)V"),
 			method="send(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/PacketCallbacks;)V")
 	public void fireblanket$asyncPacketSending(ClientConnection subject, Packet<?> pkt, PacketCallbacks listener) {
-		fireblanket$queue.add(new QueuedPacket(subject, pkt, listener));
+	    if (pkt instanceof GameJoinS2CPacket && !fireblanket$fscStarted) {
+	        fireblanket$enableFSCNow();
+	    }
+	    if (channel.attr(ClientConnection.PROTOCOL_ATTRIBUTE_KEY).get() == NetworkState.PLAY) {
+	        fireblanket$queue.add(new QueuedPacket(subject, pkt, listener));
+	    } else {
+	        sendImmediately(pkt, listener);
+	    }
 	}
+	
+	@Inject(at=@At("HEAD"), method="setCompressionThreshold", cancellable=true)
+	public void fireblanket$handleCompression(int threshold, boolean check, CallbackInfo ci) {
+	    if (fireblanket$fscStarted) {
+	        ci.cancel();
+	    }
+	}
+	
+	@Inject(at=@At("HEAD"), method="setState")
+	public void fireblanket$handleFSC(NetworkState state, CallbackInfo ci) {
+	    if (state == NetworkState.PLAY && fireblanket$fsc && !fireblanket$fscStarted) {
+	        fireblanket$enableFSCNow();
+	    }
+	}
+	
+	private void fireblanket$enableFSCNow() {
+	    fireblanket$fscStarted = true;
+        ChannelPipeline pipeline = channel.pipeline();
+        try {
+            ReassignableOutputStream ros = new ReassignableOutputStream();
+            ZstdOutputStream zos = new ZstdOutputStream(ros);
+            zos.setLevel(4);
+            zos.setLong(27);
+            zos.setCloseFrameOnFlush(true);
+            ZstdEncoder enc = new ZstdEncoder(ros, zos);
+    
+            ReassignableInputStream ris = new ReassignableInputStream();
+            ZstdInputStream zis = new ZstdInputStream(ris);
+            zis.setContinuous(true);
+            ZstdDecoder dec = new ZstdDecoder(ris, zis);
+            if (isEncrypted()) {
+                pipeline.addBefore("encrypt", "fireblanket:fsc_enc", enc);
+                pipeline.addBefore("decrypt", "fireblanket:fsc_dec", dec);
+            } else {
+                pipeline.addBefore("prepender", "fireblanket:fsc_enc", enc);
+                pipeline.addBefore("splitter", "fireblanket:fsc_dec", dec);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+	}
+
+    @Override
+    public void fireblanket$enableFullStreamCompression() {
+        fireblanket$fsc = true;
+    }
 	
 }

--- a/src/main/java/net/modfest/fireblanket/mixin/MixinClientConnection.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/MixinClientConnection.java
@@ -1,0 +1,34 @@
+package net.modfest.fireblanket.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.network.ClientConnection;
+import net.minecraft.network.PacketCallbacks;
+import net.minecraft.network.packet.Packet;
+import net.modfest.fireblanket.Fireblanket;
+
+@Mixin(ClientConnection.class)
+public class MixinClientConnection {
+
+	@Shadow
+	private void sendImmediately(Packet<?> packet, PacketCallbacks callbacks) { throw new AbstractMethodError(); }
+	
+	/**
+	 * With a lot of connections, simply the act of writing packets becomes slow.
+	 * Doing this on the server thread reduces TPS for no good reason.
+	 * 
+	 * The client already does networking roughly like this, so the protocol stack is already
+	 * designed to expect this behavior.
+	 */
+	@Redirect(at=@At(value="INVOKE", target="net/minecraft/network/ClientConnection.sendImmediately(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/PacketCallbacks;)V"),
+			method="send(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/PacketCallbacks;)V")
+	public void fireblanket$asyncPacketSending(ClientConnection subject, Packet<?> pkt, PacketCallbacks listener) {
+		Fireblanket.PACKET_QUEUE.add(() -> {
+			sendImmediately(pkt, listener);
+		});
+	}
+	
+}

--- a/src/main/java/net/modfest/fireblanket/mixin/MixinServerNetworkIo.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/MixinServerNetworkIo.java
@@ -1,0 +1,49 @@
+package net.modfest.fireblanket.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.incubator.channel.uring.IOUring;
+import io.netty.incubator.channel.uring.IOUringServerSocketChannel;
+import net.minecraft.server.ServerNetworkIo;
+import net.minecraft.util.Lazy;
+import net.modfest.fireblanket.Fireblanket;
+import net.modfest.fireblanket.mixinsupport.IOUringSupport;
+
+@Mixin(ServerNetworkIo.class)
+public class MixinServerNetworkIo {
+
+	@ModifyConstant(constant=@Constant(stringValue="Using epoll channel type"), method="bind")
+	public String fireblanket$fixLogMessage(String orig) {
+		if (IOUringSupport.ENABLED) {
+			if (IOUring.isAvailable()) {
+				return "Using io_uring channel type";
+			} else {
+				Fireblanket.LOGGER.error("Could not enable io_uring", IOUring.unavailabilityCause());
+				return "Using epoll channel type (io_uring requested, but not available)";
+			}
+		}
+		return orig;
+	}
+	
+	@ModifyVariable(at=@At(value="INVOKE", target="org/slf4j/Logger.info(Ljava/lang/String;)V", ordinal=0), method="bind", ordinal=0)
+	public Class<? extends ServerSocketChannel> fireblanket$useIoUringClass(Class<? extends ServerSocketChannel> orig) {
+		if (IOUringSupport.ENABLED && IOUring.isAvailable()) {
+			return IOUringServerSocketChannel.class;
+		}
+		return orig;
+	}
+	
+	@ModifyVariable(at=@At(value="INVOKE", target="org/slf4j/Logger.info(Ljava/lang/String;)V", ordinal=0), method="bind", ordinal=0)
+	public Lazy<? extends EventLoopGroup> fireblanket$useIoUringGroup(Lazy<? extends EventLoopGroup> orig) {
+		if (IOUringSupport.ENABLED && IOUring.isAvailable()) {
+			return IOUringSupport.CHANNEL;
+		}
+		return orig;
+	}
+	
+}

--- a/src/main/java/net/modfest/fireblanket/mixin/ServerLoginNetworkHandlerAccessor.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/ServerLoginNetworkHandlerAccessor.java
@@ -1,0 +1,15 @@
+package net.modfest.fireblanket.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.network.ClientConnection;
+import net.minecraft.server.network.ServerLoginNetworkHandler;
+
+@Mixin(ServerLoginNetworkHandler.class)
+public interface ServerLoginNetworkHandlerAccessor {
+
+    @Accessor("connection")
+    ClientConnection fireblanket$getConnection();
+    
+}

--- a/src/main/java/net/modfest/fireblanket/mixin/chunk_cache/MixinChunkDataS2CPacket.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/chunk_cache/MixinChunkDataS2CPacket.java
@@ -1,0 +1,65 @@
+package net.modfest.fireblanket.mixin.chunk_cache;
+
+import java.util.BitSet;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.network.packet.s2c.play.ChunkData;
+import net.minecraft.network.packet.s2c.play.ChunkDataS2CPacket;
+import net.minecraft.network.packet.s2c.play.LightData;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.chunk.WorldChunk;
+import net.minecraft.world.chunk.light.LightingProvider;
+import net.modfest.fireblanket.mixinsupport.CacheableChunk;
+import net.modfest.fireblanket.mixinsupport.CacheableChunk.CachedChunkPacketData;
+
+@Mixin(ChunkDataS2CPacket.class)
+public class MixinChunkDataS2CPacket {
+	
+	@Shadow @Final
+	private ChunkData chunkData;
+	@Shadow @Final
+	private LightData lightData;
+
+	@Redirect(at=@At(value="NEW", target="net/minecraft/network/packet/s2c/play/ChunkData"),
+			method="<init>(Lnet/minecraft/world/chunk/WorldChunk;Lnet/minecraft/world/chunk/light/LightingProvider;Ljava/util/BitSet;Ljava/util/BitSet;)V")
+	public ChunkData fireblanket$useCachedChunkData(WorldChunk chunk) {
+		if (chunk instanceof CacheableChunk cc) {
+			CachedChunkPacketData data = cc.fireblanket$getCachedPacket();
+			if (data != null) {
+				return data.chunkData();
+			}
+		}
+		return new ChunkData(chunk);
+	}
+	
+	@Redirect(at=@At(value="NEW", target="net/minecraft/network/packet/s2c/play/LightData"),
+			method="<init>(Lnet/minecraft/world/chunk/WorldChunk;Lnet/minecraft/world/chunk/light/LightingProvider;Ljava/util/BitSet;Ljava/util/BitSet;)V")
+	public LightData fireblanket$useCachedLightData(ChunkPos pos, LightingProvider lightProvider, BitSet skyBits, BitSet blockBits, WorldChunk chunk) {
+		if (chunk instanceof CacheableChunk cc) {
+			CachedChunkPacketData data = cc.fireblanket$getCachedPacket();
+			if (data != null) {
+				return data.lightData();
+			}
+		}
+		return new LightData(pos, lightProvider, skyBits, blockBits);
+	}
+	
+	@Inject(at=@At("TAIL"),
+			method="<init>(Lnet/minecraft/world/chunk/WorldChunk;Lnet/minecraft/world/chunk/light/LightingProvider;Ljava/util/BitSet;Ljava/util/BitSet;)V")
+	public void fireblanket$saveCachedData(WorldChunk chunk, LightingProvider light, BitSet a, BitSet b, CallbackInfo ci) {
+		if (chunk instanceof CacheableChunk cc) {
+			CachedChunkPacketData data = cc.fireblanket$getCachedPacket();
+			if (data == null) {
+				cc.fireblanket$setCachedPacket(new CachedChunkPacketData(chunkData, lightData));
+			}
+		}
+	}
+	
+}

--- a/src/main/java/net/modfest/fireblanket/mixin/chunk_cache/MixinChunkDataS2CPacket.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/chunk_cache/MixinChunkDataS2CPacket.java
@@ -10,9 +10,12 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import io.github.theepicblock.polymc.impl.Util;
+import io.github.theepicblock.polymc.impl.mixin.ChunkPacketStaticHack;
 import net.minecraft.network.packet.s2c.play.ChunkData;
 import net.minecraft.network.packet.s2c.play.ChunkDataS2CPacket;
 import net.minecraft.network.packet.s2c.play.LightData;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.chunk.WorldChunk;
 import net.minecraft.world.chunk.light.LightingProvider;
@@ -30,7 +33,9 @@ public class MixinChunkDataS2CPacket {
 	@Redirect(at=@At(value="NEW", target="net/minecraft/network/packet/s2c/play/ChunkData"),
 			method="<init>(Lnet/minecraft/world/chunk/WorldChunk;Lnet/minecraft/world/chunk/light/LightingProvider;Ljava/util/BitSet;Ljava/util/BitSet;)V")
 	public ChunkData fireblanket$useCachedChunkData(WorldChunk chunk) {
-		if (chunk instanceof CacheableChunk cc) {
+		ServerPlayerEntity polyPlayer = ChunkPacketStaticHack.player.get();
+		if ((polyPlayer == null || !Util.tryGetPolyMap(polyPlayer).isVanillaLikeMap())
+				&& chunk instanceof CacheableChunk cc) {
 			CachedChunkPacketData data = cc.fireblanket$getCachedPacket();
 			if (data != null) {
 				return data.chunkData();
@@ -42,7 +47,9 @@ public class MixinChunkDataS2CPacket {
 	@Redirect(at=@At(value="NEW", target="net/minecraft/network/packet/s2c/play/LightData"),
 			method="<init>(Lnet/minecraft/world/chunk/WorldChunk;Lnet/minecraft/world/chunk/light/LightingProvider;Ljava/util/BitSet;Ljava/util/BitSet;)V")
 	public LightData fireblanket$useCachedLightData(ChunkPos pos, LightingProvider lightProvider, BitSet skyBits, BitSet blockBits, WorldChunk chunk) {
-		if (chunk instanceof CacheableChunk cc) {
+		ServerPlayerEntity polyPlayer = ChunkPacketStaticHack.player.get();
+		if ((polyPlayer == null || !Util.tryGetPolyMap(polyPlayer).isVanillaLikeMap())
+				&& chunk instanceof CacheableChunk cc) {
 			CachedChunkPacketData data = cc.fireblanket$getCachedPacket();
 			if (data != null) {
 				return data.lightData();
@@ -54,7 +61,9 @@ public class MixinChunkDataS2CPacket {
 	@Inject(at=@At("TAIL"),
 			method="<init>(Lnet/minecraft/world/chunk/WorldChunk;Lnet/minecraft/world/chunk/light/LightingProvider;Ljava/util/BitSet;Ljava/util/BitSet;)V")
 	public void fireblanket$saveCachedData(WorldChunk chunk, LightingProvider light, BitSet a, BitSet b, CallbackInfo ci) {
-		if (chunk instanceof CacheableChunk cc) {
+		ServerPlayerEntity polyPlayer = ChunkPacketStaticHack.player.get();
+		if ((polyPlayer == null || !Util.tryGetPolyMap(polyPlayer).isVanillaLikeMap())
+				&& chunk instanceof CacheableChunk cc) {
 			CachedChunkPacketData data = cc.fireblanket$getCachedPacket();
 			if (data == null) {
 				cc.fireblanket$setCachedPacket(new CachedChunkPacketData(chunkData, lightData));

--- a/src/main/java/net/modfest/fireblanket/mixin/chunk_cache/MixinChunkDataS2CPacket.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/chunk_cache/MixinChunkDataS2CPacket.java
@@ -10,15 +10,13 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import io.github.theepicblock.polymc.impl.Util;
-import io.github.theepicblock.polymc.impl.mixin.ChunkPacketStaticHack;
 import net.minecraft.network.packet.s2c.play.ChunkData;
 import net.minecraft.network.packet.s2c.play.ChunkDataS2CPacket;
 import net.minecraft.network.packet.s2c.play.LightData;
-import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.chunk.WorldChunk;
 import net.minecraft.world.chunk.light.LightingProvider;
+import net.modfest.fireblanket.PolyMcAccess;
 import net.modfest.fireblanket.mixinsupport.CacheableChunk;
 import net.modfest.fireblanket.mixinsupport.CacheableChunk.CachedChunkPacketData;
 
@@ -33,9 +31,7 @@ public class MixinChunkDataS2CPacket {
 	@Redirect(at=@At(value="NEW", target="net/minecraft/network/packet/s2c/play/ChunkData"),
 			method="<init>(Lnet/minecraft/world/chunk/WorldChunk;Lnet/minecraft/world/chunk/light/LightingProvider;Ljava/util/BitSet;Ljava/util/BitSet;)V")
 	public ChunkData fireblanket$useCachedChunkData(WorldChunk chunk) {
-		ServerPlayerEntity polyPlayer = ChunkPacketStaticHack.player.get();
-		if ((polyPlayer == null || !Util.tryGetPolyMap(polyPlayer).isVanillaLikeMap())
-				&& chunk instanceof CacheableChunk cc) {
+        if (!PolyMcAccess.isActive() && chunk instanceof CacheableChunk cc) {
 			CachedChunkPacketData data = cc.fireblanket$getCachedPacket();
 			if (data != null) {
 				return data.chunkData();
@@ -47,9 +43,7 @@ public class MixinChunkDataS2CPacket {
 	@Redirect(at=@At(value="NEW", target="net/minecraft/network/packet/s2c/play/LightData"),
 			method="<init>(Lnet/minecraft/world/chunk/WorldChunk;Lnet/minecraft/world/chunk/light/LightingProvider;Ljava/util/BitSet;Ljava/util/BitSet;)V")
 	public LightData fireblanket$useCachedLightData(ChunkPos pos, LightingProvider lightProvider, BitSet skyBits, BitSet blockBits, WorldChunk chunk) {
-		ServerPlayerEntity polyPlayer = ChunkPacketStaticHack.player.get();
-		if ((polyPlayer == null || !Util.tryGetPolyMap(polyPlayer).isVanillaLikeMap())
-				&& chunk instanceof CacheableChunk cc) {
+		if (!PolyMcAccess.isActive() && chunk instanceof CacheableChunk cc) {
 			CachedChunkPacketData data = cc.fireblanket$getCachedPacket();
 			if (data != null) {
 				return data.lightData();
@@ -61,9 +55,7 @@ public class MixinChunkDataS2CPacket {
 	@Inject(at=@At("TAIL"),
 			method="<init>(Lnet/minecraft/world/chunk/WorldChunk;Lnet/minecraft/world/chunk/light/LightingProvider;Ljava/util/BitSet;Ljava/util/BitSet;)V")
 	public void fireblanket$saveCachedData(WorldChunk chunk, LightingProvider light, BitSet a, BitSet b, CallbackInfo ci) {
-		ServerPlayerEntity polyPlayer = ChunkPacketStaticHack.player.get();
-		if ((polyPlayer == null || !Util.tryGetPolyMap(polyPlayer).isVanillaLikeMap())
-				&& chunk instanceof CacheableChunk cc) {
+        if (!PolyMcAccess.isActive() && chunk instanceof CacheableChunk cc) {
 			CachedChunkPacketData data = cc.fireblanket$getCachedPacket();
 			if (data == null) {
 				cc.fireblanket$setCachedPacket(new CachedChunkPacketData(chunkData, lightData));

--- a/src/main/java/net/modfest/fireblanket/mixin/chunk_cache/MixinWorldChunk.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/chunk_cache/MixinWorldChunk.java
@@ -1,0 +1,63 @@
+package net.modfest.fireblanket.mixin.chunk_cache;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.registry.Registry;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.HeightLimitView;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.ChunkSection;
+import net.minecraft.world.chunk.UpgradeData;
+import net.minecraft.world.chunk.WorldChunk;
+import net.minecraft.world.gen.chunk.BlendingData;
+import net.modfest.fireblanket.mixinsupport.CacheableChunk;
+
+@Mixin(WorldChunk.class)
+public abstract class MixinWorldChunk extends Chunk implements CacheableChunk {
+
+	public MixinWorldChunk(ChunkPos pos, UpgradeData upgradeData, HeightLimitView heightLimitView, Registry<Biome> biomeRegistry, long inhabitedTime, ChunkSection[] sectionArray, BlendingData blendingData) {
+		super(pos, upgradeData, heightLimitView, biomeRegistry, inhabitedTime, sectionArray, blendingData);
+	}
+
+	private CachedChunkPacketData fireblanket$cachedPacket;
+
+	@Inject(at=@At("RETURN"), method="setBlockState")
+	public void fireblanket$invalidateOnSetBlockState(BlockPos bp, BlockState bs, boolean moved, CallbackInfoReturnable<BlockState> ci) {
+		fireblanket$cachedPacket = null;
+	}
+	@Inject(at=@At("RETURN"), method="removeBlockEntity")
+	public void fireblanket$invalidateOnRemoveBlockEntity(BlockPos pos, CallbackInfo ci) {
+		fireblanket$cachedPacket = null;
+	}
+	@Inject(at=@At("RETURN"), method="setBlockEntity")
+	public void fireblanket$invalidateOnSetBlockEntity(BlockEntity be, CallbackInfo ci) {
+		fireblanket$cachedPacket = null;
+	}
+	
+	@Override
+	public void setNeedsSaving(boolean needsSaving) {
+		// called by e.g. BlockEntity.markDirty, and also by any mods that need it
+		// unfortunately, some methods inside Chunk don't use this, so we need to do it ourselves above
+		super.setNeedsSaving(needsSaving);
+		fireblanket$cachedPacket = null;
+	}
+	
+	@Override
+	public CachedChunkPacketData fireblanket$getCachedPacket() {
+		return fireblanket$cachedPacket;
+	}
+
+	@Override
+	public void fireblanket$setCachedPacket(CachedChunkPacketData pkt) {
+		fireblanket$cachedPacket = pkt;
+	}
+	
+}

--- a/src/main/java/net/modfest/fireblanket/mixin/mythicmetals/MixinCarmotShield.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/mythicmetals/MixinCarmotShield.java
@@ -1,0 +1,30 @@
+package net.modfest.fireblanket.mixin.mythicmetals;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import dev.onyxstudios.cca.api.v3.component.ComponentKey;
+
+@Pseudo
+@Mixin(targets="nourl/mythicmetals/armor/CarmotShield")
+public abstract class MixinCarmotShield {
+
+	@Shadow
+	public abstract boolean shouldRenderShield();
+	
+	/**
+	 * Unconditional sync every tick for every player. Sloooooow.
+	 * Make it conditional.
+	 */
+	@Redirect(at=@At(value="INVOKE", target="dev/onyxstudios/cca/api/v3/component/ComponentKey.sync(Ljava/lang/Object;)V"),
+			method="tickShield")
+	public void fireblanket$preventSync(ComponentKey key, Object provider) {
+		if (shouldRenderShield()) {
+			key.sync(provider);
+		}
+	}
+	
+}

--- a/src/main/java/net/modfest/fireblanket/mixinsupport/CacheableChunk.java
+++ b/src/main/java/net/modfest/fireblanket/mixinsupport/CacheableChunk.java
@@ -1,0 +1,13 @@
+package net.modfest.fireblanket.mixinsupport;
+
+import net.minecraft.network.packet.s2c.play.ChunkData;
+import net.minecraft.network.packet.s2c.play.LightData;
+
+public interface CacheableChunk {
+
+	public record CachedChunkPacketData(ChunkData chunkData, LightData lightData) {}
+	
+	CachedChunkPacketData fireblanket$getCachedPacket();
+	void fireblanket$setCachedPacket(CachedChunkPacketData pkt);
+	
+}

--- a/src/main/java/net/modfest/fireblanket/mixinsupport/FSCConnection.java
+++ b/src/main/java/net/modfest/fireblanket/mixinsupport/FSCConnection.java
@@ -1,0 +1,7 @@
+package net.modfest.fireblanket.mixinsupport;
+
+public interface FSCConnection {
+
+    void fireblanket$enableFullStreamCompression();
+    
+}

--- a/src/main/java/net/modfest/fireblanket/mixinsupport/IOUringSupport.java
+++ b/src/main/java/net/modfest/fireblanket/mixinsupport/IOUringSupport.java
@@ -1,0 +1,21 @@
+package net.modfest.fireblanket.mixinsupport;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
+import net.minecraft.util.Lazy;
+
+public class IOUringSupport {
+
+	public static final boolean ENABLED = Boolean.getBoolean("fireblanket.useIoUring");
+    
+	@SuppressWarnings("deprecation")
+	public static final Lazy<IOUringEventLoopGroup> CHANNEL = new Lazy<>(() ->
+		new IOUringEventLoopGroup(0, new ThreadFactoryBuilder()
+				.setNameFormat("Netty IO URing Server IO #%d")
+				.setDaemon(true)
+				.build())
+		);
+
+	
+}

--- a/src/main/java/net/modfest/fireblanket/net/ZstdDecoder.java
+++ b/src/main/java/net/modfest/fireblanket/net/ZstdDecoder.java
@@ -1,0 +1,31 @@
+package net.modfest.fireblanket.net;
+
+import java.util.List;
+
+import com.github.luben.zstd.ZstdInputStream;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.ByteBufOutputStream;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+import net.modfest.fireblanket.ReassignableInputStream;
+
+public class ZstdDecoder extends MessageToMessageDecoder<ByteBuf> {
+
+    private final ReassignableInputStream in;
+    private final ZstdInputStream stream;
+
+    public ZstdDecoder(ReassignableInputStream in, ZstdInputStream stream) {
+        this.in = in;
+        this.stream = stream;
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) throws Exception {
+        ByteBuf buf = ctx.alloc().buffer();
+        in.setDelegate(new ByteBufInputStream(msg, false));
+        stream.transferTo(new ByteBufOutputStream(buf));
+        out.add(buf);
+    }
+    
+}

--- a/src/main/java/net/modfest/fireblanket/net/ZstdEncoder.java
+++ b/src/main/java/net/modfest/fireblanket/net/ZstdEncoder.java
@@ -1,0 +1,71 @@
+package net.modfest.fireblanket.net;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+
+import com.github.luben.zstd.ZstdOutputStream;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToByteEncoder;
+import net.modfest.fireblanket.Fireblanket;
+import net.modfest.fireblanket.ReassignableOutputStream;
+
+public class ZstdEncoder extends MessageToByteEncoder<ByteBuf> {
+
+    private static final ScheduledExecutorService sched = Executors.newSingleThreadScheduledExecutor();
+    
+    private static final LongAdder inBytes = new LongAdder();
+    private static final LongAdder outBytes = new LongAdder();
+    
+    static {
+        sched.scheduleAtFixedRate(() -> {
+            Fireblanket.LOGGER.info("Zstd ratio past 5m: "+((double)inBytes.sumThenReset()/outBytes.sumThenReset()));
+        }, 5, 5, TimeUnit.MINUTES);
+    }
+    
+    private static final long FLUSH_FREQUENCY = TimeUnit.MILLISECONDS.toNanos(50);
+    
+    private final ReassignableOutputStream out;
+    private final ZstdOutputStream stream;
+
+    private ScheduledFuture<?> future = null;
+    
+    private long lastFlush = System.nanoTime();
+
+    public ZstdEncoder(ReassignableOutputStream out, ZstdOutputStream stream) {
+        this.out = out;
+        this.stream = stream;
+    }
+
+    @Override
+    protected void encode(ChannelHandlerContext ctx, ByteBuf msg, ByteBuf out) throws Exception {
+        if (future != null) {
+            future.cancel(false);
+            future = null;
+        }
+        inBytes.add(msg.readableBytes());
+        this.out.setDelegate(new ByteBufOutputStream(out));
+        int start = out.writerIndex();
+        new ByteBufInputStream(msg, false).transferTo(stream);
+        if (System.nanoTime()-lastFlush > FLUSH_FREQUENCY) {
+            lastFlush = System.nanoTime();
+            stream.flush();
+        } else {
+            Channel ch = ctx.channel();
+            future = sched.schedule(() -> {
+                future = null;
+                ch.writeAndFlush(Unpooled.EMPTY_BUFFER);
+            }, 50, TimeUnit.MILLISECONDS);
+        }
+        outBytes.add(out.writerIndex()-start);
+    }
+    
+}

--- a/src/main/resources/fireblanket.mixins.json
+++ b/src/main/resources/fireblanket.mixins.json
@@ -14,7 +14,8 @@
     "improved_be_sync.MixinBlockEntity",
     "improved_be_sync.MixinChunkHolder",
     "pehkui.MixinScaleUtils",
-    "pswg.MixinComplexCollisionManager"
+    "pswg.MixinComplexCollisionManager",
+    "mythicmetals.MixinCarmotShield"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/fireblanket.mixins.json
+++ b/src/main/resources/fireblanket.mixins.json
@@ -16,7 +16,9 @@
     "pehkui.MixinScaleUtils",
     "pswg.MixinComplexCollisionManager",
     "mythicmetals.MixinCarmotShield",
-    "MixinClientConnection"
+    "MixinClientConnection",
+    "chunk_cache.MixinChunkDataS2CPacket",
+    "chunk_cache.MixinWorldChunk"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/fireblanket.mixins.json
+++ b/src/main/resources/fireblanket.mixins.json
@@ -19,7 +19,9 @@
     "MixinClientConnection",
     "chunk_cache.MixinChunkDataS2CPacket",
     "chunk_cache.MixinWorldChunk",
-    "ClientConnectionAccessor"
+    "ClientConnectionAccessor",
+    "MixinServerNetworkIo",
+    "ServerLoginNetworkHandlerAccessor"
   ],
   "injectors": {
     "defaultRequire": 1
@@ -31,6 +33,7 @@
     "client.be_masking.MixinRebuildTask",
     "client.be_masking.sodium.MixinChunkRenderRebuildTask",
     "client.vbo_opto.MixinShaderProgram",
-    "client.vbo_opto.MixinVertexBuffer"
+    "client.vbo_opto.MixinVertexBuffer",
+    "ClientLoginNetworkHandlerAccessor"
   ]
 }

--- a/src/main/resources/fireblanket.mixins.json
+++ b/src/main/resources/fireblanket.mixins.json
@@ -15,7 +15,8 @@
     "improved_be_sync.MixinChunkHolder",
     "pehkui.MixinScaleUtils",
     "pswg.MixinComplexCollisionManager",
-    "mythicmetals.MixinCarmotShield"
+    "mythicmetals.MixinCarmotShield",
+    "MixinClientConnection"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/fireblanket.mixins.json
+++ b/src/main/resources/fireblanket.mixins.json
@@ -18,7 +18,8 @@
     "mythicmetals.MixinCarmotShield",
     "MixinClientConnection",
     "chunk_cache.MixinChunkDataS2CPacket",
-    "chunk_cache.MixinWorldChunk"
+    "chunk_cache.MixinWorldChunk",
+    "ClientConnectionAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Confirmed this doesn't break the mod, in case it gets showcased.

Also I had a brain blast and accidentally tripled our performance — I tested it again locally under stress conditions to confirm no crashes from bad async. LinkedBlockingQueue should ensure packets remain in the proper order, despite being shuttled off to another thread.

(Before)

![image](https://github.com/ModFest/fireblanket/assets/6185037/c470f705-b11c-4653-8010-081dcfba1fd1)

Also fixed the ChunkDataS2CPacket bottleneck via caching — Patbox made a good point that the chunk data doesn't change frequently, so it's wasteful to constantly recompute it. The cache is skipped for users with PolyMc enabled.
