### PR TITLE
Buffer builder optimizations

### DIFF
--- a/src/main/java/net/modfest/fireblanket/client/render/ExtendedVertexFormat.java
+++ b/src/main/java/net/modfest/fireblanket/client/render/ExtendedVertexFormat.java
@@ -1,0 +1,9 @@
+package net.modfest.fireblanket.client.render;
+
+import net.minecraft.client.render.VertexFormatElement;
+
+public interface ExtendedVertexFormat {
+    Element[] fireblanket$getExtendedElements();
+
+    static record Element(VertexFormatElement actual, int increment, int byteLength) { }
+}

--- a/src/main/java/net/modfest/fireblanket/mixin/client/bufferbuilder_opto/MixinBufferBuilder.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/client/bufferbuilder_opto/MixinBufferBuilder.java
@@ -1,0 +1,102 @@
+package net.modfest.fireblanket.mixin.client.bufferbuilder_opto;
+
+import java.nio.ByteBuffer;
+
+import org.lwjgl.system.MemoryUtil;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.render.BufferBuilder;
+import net.minecraft.client.render.BufferVertexConsumer;
+import net.minecraft.client.render.FixedColorVertexConsumer;
+import net.minecraft.client.render.VertexFormat;
+import net.minecraft.client.render.VertexFormatElement;
+import net.modfest.fireblanket.client.render.ExtendedVertexFormat;
+
+@Mixin(BufferBuilder.class)
+public abstract class MixinBufferBuilder extends FixedColorVertexConsumer implements BufferVertexConsumer {
+
+    @Shadow
+    private ByteBuffer buffer;
+
+    @Shadow
+    private int elementOffset;
+
+    @Shadow
+    private VertexFormatElement currentElement;
+
+    @Shadow
+    private int currentElementId;
+
+    private long fireblanket$pBuffer = -1;
+    private ExtendedVertexFormat.Element[] fireblanket$vertexFormatExtendedElements;
+    private ExtendedVertexFormat.Element fireblanket$currentExtendedElement;
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void fireblanket$getBufferPointer(int initialCapacity, CallbackInfo ci) {
+        fireblanket$pBuffer = MemoryUtil.memAddress(buffer);
+    }
+
+    @Inject(method = "grow(I)V", at = @At(value = "FIELD", target = "Lnet/minecraft/client/render/BufferBuilder;buffer:Ljava/nio/ByteBuffer;", shift = At.Shift.AFTER))
+    private void fireblanket$getGrownBufferPointer(int size, CallbackInfo ci) {
+        fireblanket$pBuffer = MemoryUtil.memAddress(buffer);
+    }
+
+    @Inject(method = "setFormat", at = @At(value = "FIELD", target = "Lnet/minecraft/client/render/BufferBuilder;format:Lnet/minecraft/client/render/VertexFormat;", shift = At.Shift.AFTER))
+    private void fireblanket$cacheVertexFormatElements(VertexFormat format, CallbackInfo ci) {
+        fireblanket$vertexFormatExtendedElements = ((ExtendedVertexFormat) format).fireblanket$getExtendedElements();
+        fireblanket$currentExtendedElement = fireblanket$vertexFormatExtendedElements[0];
+    }
+
+    /**
+     * @reason The original `nextElement` is horrible for the JVM. It makes 8 dereferences scattered across the heap, does a modulo when it doesn't have to, and calls it's self
+     * @author Maximum
+     */
+    @Override
+    @Overwrite
+    public void nextElement() {
+        if ((currentElementId += fireblanket$currentExtendedElement.increment()) >= fireblanket$vertexFormatExtendedElements.length)
+            currentElementId -= fireblanket$vertexFormatExtendedElements.length;
+        elementOffset += fireblanket$currentExtendedElement.byteLength();
+        fireblanket$currentExtendedElement = fireblanket$vertexFormatExtendedElements[currentElementId];
+        currentElement = fireblanket$currentExtendedElement.actual();
+
+        if (colorFixed && currentElement.getType() == VertexFormatElement.Type.COLOR)
+            BufferVertexConsumer.super.color(fixedRed, fixedGreen, fixedBlue, fixedAlpha);
+    }
+
+    /**
+     * @reason Minor performance improvement
+     * @author Maximum
+     */
+    @Override
+    @Overwrite
+    public void putByte(int index, byte value) {
+        MemoryUtil.memPutByte(fireblanket$pBuffer + elementOffset + index, value);
+    }
+
+    /**
+     * @reason Minor performance improvement
+     * @author Maximum
+     */
+    @Override
+    @Overwrite
+    public void putShort(int index, short value) {
+        MemoryUtil.memPutShort(fireblanket$pBuffer + elementOffset + index, value);
+    }
+
+    /**
+     * @reason Minor performance improvement
+     * @author Maximum
+     */
+    @Override
+    @Overwrite
+    public void putFloat(int index, float value) {
+        MemoryUtil.memPutFloat(fireblanket$pBuffer + elementOffset + index, value);
+    }
+
+}

--- a/src/main/java/net/modfest/fireblanket/mixin/client/bufferbuilder_opto/MixinVertexFormat.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/client/bufferbuilder_opto/MixinVertexFormat.java
@@ -1,0 +1,53 @@
+package net.modfest.fireblanket.mixin.client.bufferbuilder_opto;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import net.minecraft.client.render.VertexFormat;
+import net.minecraft.client.render.VertexFormatElement;
+import net.modfest.fireblanket.client.render.ExtendedVertexFormat;
+
+@Mixin(VertexFormat.class)
+public class MixinVertexFormat implements ExtendedVertexFormat {
+
+    @Shadow @Final
+    private ImmutableList<VertexFormatElement> elements;
+
+    private ExtendedVertexFormat.Element[] fireblanket$extendedElements;
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void fireblanket$createElementArray(ImmutableMap<String, VertexFormatElement> elementMap, CallbackInfo ci) {
+        this.fireblanket$extendedElements = new ExtendedVertexFormat.Element[this.elements.size()];
+
+        VertexFormatElement currentElement = elements.get(0);
+        int id = 0;
+        for (VertexFormatElement element : this.elements) {
+            if (element.getType() == VertexFormatElement.Type.PADDING) continue;
+
+            int oldId = id;
+            int byteLength = 0;
+
+            do {
+                if (++id >= this.fireblanket$extendedElements.length)
+                    id -= this.fireblanket$extendedElements.length;
+                byteLength += currentElement.getByteLength();
+                currentElement = this.elements.get(id);
+            } while (currentElement.getType() == VertexFormatElement.Type.PADDING);
+
+            this.fireblanket$extendedElements[oldId] = new ExtendedVertexFormat.Element(element, id - oldId, byteLength);
+        }
+    }
+
+    @Override
+    public ExtendedVertexFormat.Element[] fireblanket$getExtendedElements() {
+        return this.fireblanket$extendedElements;
+    }
+
+}

--- a/src/main/resources/fireblanket.mixins.json
+++ b/src/main/resources/fireblanket.mixins.json
@@ -37,6 +37,8 @@
 	"client.be_masking.MixinBlockEntityRenderDispatcher",
 	"client.be_masking.MixinRebuildTask",
 	"client.be_masking.sodium.MixinChunkRenderRebuildTask",
+	"client.bufferbuilder_opto.MixinBufferBuilder",
+	"client.bufferbuilder_opto.MixinVertexFormat",
 	"client.entity_masking.MixinEntityRenderer",
 	"client.vbo_opto.MixinShaderProgram",
 	"client.vbo_opto.MixinVertexBuffer",


### PR DESCRIPTION
Tested this around the entire blanketcon 23 map, didn't see any visual glitches
This provides a major performance improvement for create's block entities at least on my machine