### PR TITLE
Add option to store block data as a flat array for faster access

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.1+build.9
 loader_version=0.14.21
 
 # Mod Properties
-mod_version=0.3.0
+mod_version=0.3.1
 maven_group=net.modfest
 archives_base_name=fireblanket
 

--- a/src/main/java/net/modfest/fireblanket/FireblanketMixin.java
+++ b/src/main/java/net/modfest/fireblanket/FireblanketMixin.java
@@ -16,6 +16,7 @@ public class FireblanketMixin implements IMixinConfigPlugin {
 	public static final boolean DO_MASKING = Boolean.getBoolean("fireblanket.masking");
 	private static final boolean DO_CHUNK_CACHE = System.getProperty("fireblanket.loadRadius") != null;
 	public static final boolean ALLOW_LAMBDAMAP_SAVING = Boolean.getBoolean("fireblanket.allowLambdaMapSaving");
+	private static final boolean DO_CHUNKSECTION_OPTO = Boolean.getBoolean("fireblanket.flattenChunkPalettes");
 
 	@Override
 	public void onLoad(String mixinPackage) {
@@ -101,6 +102,10 @@ public class FireblanketMixin implements IMixinConfigPlugin {
 		
 		if (mixinClassName.contains("lambdamap")) {
 			return !ALLOW_LAMBDAMAP_SAVING;
+		}
+
+		if (mixinClassName.contains("block_format")) {
+			return DO_CHUNKSECTION_OPTO;
 		}
 
 		return true;

--- a/src/main/java/net/modfest/fireblanket/mixin/block_format/MixinChunkSection.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/block_format/MixinChunkSection.java
@@ -1,0 +1,240 @@
+package net.modfest.fireblanket.mixin.block_format;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.util.crash.CrashException;
+import net.minecraft.util.crash.CrashReport;
+import net.minecraft.util.crash.CrashReportSection;
+import net.minecraft.world.chunk.ChunkSection;
+import net.minecraft.world.chunk.PalettedContainer;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Augments the chunk palette to primarily use a flat array to store blockstate ids, speeding up blockstate access and
+ * setting. As many minecraft structures rely on the palette, when the palette is queried, for saving or networking,
+ * it flushes the data from the flat array back into the palette.
+ */
+@Mixin(ChunkSection.class)
+public abstract class MixinChunkSection {
+	// Will be real due to mixin plugin
+
+	private static final int MASK_BITS = 1048575;
+
+	@Shadow @Final private PalettedContainer<BlockState> blockStateContainer;
+	@Shadow private short nonEmptyBlockCount;
+	@Shadow private short nonEmptyFluidCount;
+	@Shadow private short randomTickableBlockCount;
+
+	// 20 bits per block, so 3 blocks per long. ceil(4096/3) --> 1366
+	private final long[] fireblanket$denseBlockStorage = new long[1366];
+
+	private final AtomicLong fireblanket$stamp = new AtomicLong();
+	private boolean fireblanket$dirty = false;
+
+	@Redirect(method = "<init>(Lnet/minecraft/world/chunk/PalettedContainer;Lnet/minecraft/world/chunk/ReadableContainer;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/chunk/ChunkSection;calculateCounts()V"))
+	private void fireblanket$setupState(ChunkSection instance) {
+		PalettedContainer<BlockState> container = this.blockStateContainer;
+
+		fireblanket$applyFromPalette(container);
+	}
+
+	private void fireblanket$applyFromPalette(PalettedContainer<BlockState> container) {
+		for (int y = 0; y < 16; y++) {
+			for (int x = 0; x < 16; x++) {
+				for (int z = 0; z < 16; z++) {
+					setBlockState(x, y, z, container.get(x, y, z), false);
+				}
+			}
+		}
+
+		fireblanket$dirty = false;
+	}
+
+	/**
+	 * @author Jasmine
+	 *
+	 * @reason Optimized with flat array
+	 */
+	@Overwrite
+	public BlockState setBlockState(int x, int y, int z, BlockState state, boolean lock) {
+		// Calculate math needed for both stages before the barrier
+		int rawIdx = arrayIndex(x, y, z);
+		int arrIdx = rawIdx / 3;
+		int shlIdx = rawIdx % 3;
+		int shift = 20 * shlIdx;
+
+		// Grab a stamp to compare against after we're done writing, just in case anything weird happens
+		long stamp = this.fireblanket$stamp.incrementAndGet();
+
+		BlockState oldState;
+		try {
+			// Get the old state that we already see
+			long oldBits = this.fireblanket$denseBlockStorage[arrIdx];
+			oldState = Block.STATE_IDS.get((int)(oldBits >>> shift) & MASK_BITS);
+
+			// Make data for the new state
+			long newId = Block.STATE_IDS.getRawId(state);
+			long newBitsIn = newId << shift;
+			long mask = (long) MASK_BITS << shift;
+
+			// Replace old location with zeros, then apply the new bits
+			long newBits = (oldBits & ~mask) | (newBitsIn & mask);
+
+			// Commit to memory, mark dirty
+			this.fireblanket$denseBlockStorage[arrIdx] = newBits;
+			fireblanket$dirty = true;
+		} finally {
+			// Nightmare scenario. The stamp is not the same as the one we obtained at the start, so
+			// we were probably written to concurrently. This is bad, we need to stop immediately.
+			if (this.fireblanket$stamp.get() != stamp) {
+				Map<Thread, StackTraceElement[]> traces = Thread.getAllStackTraces();
+				String dumps = traces.entrySet().stream()
+						.map(MixinChunkSection::formatThreadDump)
+						.collect(Collectors.joining("\n"));
+
+				String error = "Accessing ChunkSection from multiple threads!";
+				CrashReport crashReport = new CrashReport(error, new IllegalStateException(error));
+				CrashReportSection crashReportSection = crashReport.addElement("Thread dumps");
+				crashReportSection.add("Thread dumps", dumps);
+				throw new CrashException(crashReport);
+			}
+		}
+
+		// Vanilla counting logic
+
+		FluidState fluidState = oldState.getFluidState();
+		FluidState fluidState2 = state.getFluidState();
+		if (!oldState.isAir()) {
+			--this.nonEmptyBlockCount;
+			if (oldState.hasRandomTicks()) {
+				--this.randomTickableBlockCount;
+			}
+		}
+
+		if (!fluidState.isEmpty()) {
+			--this.nonEmptyFluidCount;
+		}
+
+		if (!state.isAir()) {
+			++this.nonEmptyBlockCount;
+			if (state.hasRandomTicks()) {
+				++this.randomTickableBlockCount;
+			}
+		}
+
+		if (!fluidState2.isEmpty()) {
+			++this.nonEmptyFluidCount;
+		}
+
+		return oldState;
+	}
+
+	private static String formatThreadDump(Map.Entry<Thread, StackTraceElement[]> e) {
+		return e.getKey().getName() + ": \n\tat " + Arrays.stream(e.getValue()).map(Object::toString).collect(Collectors.joining("\n\tat "));
+	}
+
+	/**
+	 * @author Jasmine
+	 *
+	 * @reason Optimized with flat array
+	 */
+	@Overwrite
+	public BlockState getBlockState(int x, int y, int z) {
+		int rawIdx = arrayIndex(x, y, z);
+		// Since this is a constant divmod, it *should* be ok, and C2 shouldn't emit any divisions
+		// TODO: check generated assembly and use manual magic fake division if needed
+		int arrIdx = rawIdx / 3;
+		int shlIdx = rawIdx % 3;
+
+		long rawVal = (this.fireblanket$denseBlockStorage[arrIdx] >>> (20L * shlIdx)) & MASK_BITS;
+
+		return Block.STATE_IDS.get((int) rawVal);
+	}
+
+	private static int arrayIndex(int x, int y, int z) {
+		// Y before XZ is typically the access pattern found in extended periods of blockstate lookup
+		return y * 256 + x * 16 + z;
+	}
+
+	/**
+	 * @author Jasmine
+	 *
+	 * @reason Optimized with flat array. Vanilla duplicates the getBlockState logic, whereas here just calls the
+	 * method for simplicity
+	 */
+	@Overwrite
+	public FluidState getFluidState(int x, int y, int z) {
+		return getBlockState(x, y, z).getFluidState();
+	}
+
+	/**
+	 * @author Jasmine
+	 *
+	 * @reason Flush all updates to the container
+	 */
+	@Overwrite
+	public PalettedContainer<BlockState> getBlockStateContainer() {
+		if (fireblanket$dirty) {
+			for (int y = 0; y < 16; y++) {
+				for (int x = 0; x < 16; x++) {
+					for (int z = 0; z < 16; z++) {
+						this.blockStateContainer.swapUnsafe(x, y, z, getBlockState(x, y, z));
+					}
+				}
+			}
+		}
+
+		fireblanket$dirty = false;
+
+		return this.blockStateContainer;
+	}
+
+	// Originally this was one injector, but broke horribly, so we're doing it the spacious way instead
+	@Inject(method = "toPacket", at = @At("HEAD"))
+	private void fireblanket$resetUnderlyingStateToPacket(PacketByteBuf buf, CallbackInfo ci) {
+		getBlockStateContainer();
+	}
+
+	@Inject(method = "getPacketSize", at = @At("HEAD"))
+	private void fireblanket$resetUnderlyingStateGetPacketSize(CallbackInfoReturnable<Integer> cir) {
+		getBlockStateContainer();
+	}
+
+	@Inject(method = "hasAny", at = @At("HEAD"))
+	private void fireblanket$resetUnderlyingStateHasAny(Predicate<BlockState> predicate, CallbackInfoReturnable<Boolean> cir) {
+		getBlockStateContainer();
+	}
+
+	// Dear god please no one use this on their client. Support is provided for completeness.
+	@Inject(method = "readDataPacket", at = @At("TAIL"))
+	private void fireblanket$resetForPacketBadTerrible(PacketByteBuf buf, CallbackInfo ci) {
+		fireblanket$applyFromPalette(this.blockStateContainer);
+	}
+
+	/**
+	 * @author Jasmine
+	 *
+	 * @reason We don't really need this
+	 */
+	@Overwrite
+	public void calculateCounts() {
+		// Only ever used in one place, which is redirected, so I figure it's better to implement this on a need basis.
+		throw new UnsupportedOperationException("Not implemented");
+	}
+}

--- a/src/main/resources/fireblanket.mixins.json
+++ b/src/main/resources/fireblanket.mixins.json
@@ -10,6 +10,7 @@
 	"MixinEntitySelector",
 	"MixinRecipeManager",
 	"MixinServerPlayerEntity",
+	"block_format.MixinChunkSection",
 	"entity_ticking.MixinMinecraftServer",
 	"entity_ticking.MixinThreadedAnvilChunkStorage",
 	"entity_ticking.create.MixinSuperGlueEntity",


### PR DESCRIPTION
`-Dfireblanket.flattenChunkPalettes=true`

This option allows for the storage of chunk data in a flat array, using 20 bits per element, instead of using the vanilla palette system. The palette is still needed for world storage and networking, so it is updated on the fly, as necessary.

This is the primary revision, there are some further optimizations possible here, but it'll be good to get this in first.