### PR TITLE
reduce Create's Mechanical/Windmill/Clockwork Bearing sync frequency

### DIFF
--- a/src/main/java/net/modfest/fireblanket/mixin/create/AccessorSmartBlockEntity.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/create/AccessorSmartBlockEntity.java
@@ -1,0 +1,13 @@
+package net.modfest.fireblanket.mixin.create;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Pseudo
+@Mixin(targets = "com.simibubi.create.foundation.blockEntity.SmartBlockEntity")
+public interface AccessorSmartBlockEntity {
+	@Accessor(value = "lazyTickRate", remap = false) int fireblanket$getLazyTickRate();
+	@Invoker(value = "setLazyTickRate", remap = false) void fireblanket$setLazyTickRate(int r);
+}

--- a/src/main/java/net/modfest/fireblanket/mixin/create/MixinMechanicalBearingBlockEntity.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/create/MixinMechanicalBearingBlockEntity.java
@@ -1,0 +1,37 @@
+package net.modfest.fireblanket.mixin.create;
+
+import net.minecraft.nbt.NbtCompound;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Pseudo
+@Mixin(targets = {
+	"com.simibubi.create.content.contraptions.bearing.MechanicalBearingBlockEntity", //WindmillBearing extends it
+	"com.simibubi.create.content.contraptions.bearing.ClockworkBearingBlockEntity"
+})
+public class MixinMechanicalBearingBlockEntity {
+	@Unique private static final int NEW_DEFAULT_LAZY_RATE = 50;
+	
+	@ModifyConstant(method = "<init>", constant = @Constant(intValue = 3), remap = false)
+	private int fireblanket$reduceLazyTickRate(int orig) {
+		return NEW_DEFAULT_LAZY_RATE;
+	}
+	
+	@Inject(method = "write", at = @At("RETURN"), remap = false)
+	public void fireblanket$onWrite(NbtCompound tag, boolean clientPacket, CallbackInfo ci) {
+		int i = ((AccessorSmartBlockEntity) this).fireblanket$getLazyTickRate();
+		if(i != NEW_DEFAULT_LAZY_RATE) tag.putInt("fbLazy", i);
+	}
+	
+	@Inject(method = "read", at = @At("RETURN"), remap = false)
+	public void fireblanket$onRead(NbtCompound tag, boolean clientPacket, CallbackInfo ci) {
+		int i = tag.getInt("fbLazy");
+		if(i > 0) ((AccessorSmartBlockEntity) this).fireblanket$setLazyTickRate(i);
+	}
+}

--- a/src/main/resources/fireblanket.mixins.json
+++ b/src/main/resources/fireblanket.mixins.json
@@ -22,6 +22,8 @@
 	"pehkui.MixinScaleUtils",
 	"pswg.MixinComplexCollisionManager",
 	"mythicmetals.MixinCarmotShield",
+	"create.MixinMechanicalBearingBlockEntity",
+	"create.AccessorSmartBlockEntity",
 	"fsc.MixinClientConnection",
 	"fsc.MixinSizePrepender",
 	"fsc.MixinSplitterHandler",


### PR DESCRIPTION
Mechanical bearing syncs are one of the top sources of network packets just because people have placed a *lot* of them (especially in Solar) and they send a packet every 3 ticks rain-or-shine. Over a 139-second capture with my tool i observed 11,625 `create:mechanical_bearing` sync packets, or 83 per second.

It's important for these to sync *occasionally* since it's how the angle stays accurate, but a lot of these bearings are just used for idly spinning signs or other decorative purposes where accurate collision is not very important.

This pr hacks the default interval from every 3 ticks to every 50 ticks, and if an NBT tag `fbLazy` exists containing a positive integer, the sync interval will be set to that, so it can be customized per-bearing if need be.

further work:

* probably can check `clientPacket` in onWrite
* to spread out the spikes caused by all bearings syncing at once, experiment with randomizing [lazyTickCounter](https://github.com/Fabricators-of-Create/Create/blob/mc1.20.1/fabric/dev/src/main/java/com/simibubi/create/foundation/blockEntity/SmartBlockEntity.java#L75)
* I haven't been able to test the clockwork bearing well due to my blanketcon singleplayer world constantly crashing from weird ecotones chunk generator stuff :/