### PR TITLE
Add allow_trigger_explosions gamerule

### DIFF
--- a/src/main/java/net/modfest/fireblanket/Fireblanket.java
+++ b/src/main/java/net/modfest/fireblanket/Fireblanket.java
@@ -99,6 +99,11 @@ public class Fireblanket implements ModInitializer {
 			.category(GameRuleCategory.PLAYER)
 			.buildAndRegister(FireblanketConstants.id("adventure_wind_charge_interaction"));
 
+	public static final GameRule<Boolean> ALLOW_TRIGGER_EXPLOSIONS =
+		GameRuleBuilder.forBoolean(false)
+			.category(GameRuleCategory.MISC)
+			.buildAndRegister(FireblanketConstants.id("allow_trigger_explosions"));
+
 	public static final Logger LOGGER = LoggerFactory.getLogger("Fireblanket");
 
 	public record QueuedPacket(Connection conn, Packet<?> packet, ChannelFutureListener listener) {

--- a/src/main/java/net/modfest/fireblanket/mixin/adventure_fix/MixinServerExplosion.java
+++ b/src/main/java/net/modfest/fireblanket/mixin/adventure_fix/MixinServerExplosion.java
@@ -1,12 +1,15 @@
 package net.modfest.fireblanket.mixin.adventure_fix;
 
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.ServerExplosion;
 import net.modfest.fireblanket.Fireblanket;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 
 /**
@@ -14,12 +17,21 @@ import org.spongepowered.asm.mixin.injection.At;
  **/
 @Mixin(ServerExplosion.class)
 public abstract class MixinServerExplosion implements Explosion {
+	@Shadow
+	@Final
+	private ServerLevel level;
+
 	@ModifyReturnValue(method = "canTriggerBlocks", at = @At("RETURN"))
 	private boolean modifyReturn(final boolean original) {
+		if (original && !this.level.getGameRules().get(Fireblanket.ALLOW_TRIGGER_EXPLOSIONS)) {
+			return false;
+		}
+
 		if (original && this.getIndirectSourceEntity() instanceof ServerPlayer player) {
 			return player.gameMode() != GameType.ADVENTURE
-				   || this.level().getGameRules().get(Fireblanket.ADVENTURE_WIND_CHARGE_INTERACTION);
+				|| this.level.getGameRules().get(Fireblanket.ADVENTURE_WIND_CHARGE_INTERACTION);
 		}
+
 		return original;
 	}
 }

--- a/src/main/resources/assets/fireblanket/lang/en_us.json
+++ b/src/main/resources/assets/fireblanket/lang/en_us.json
@@ -7,6 +7,8 @@
 	"gamerule.fireblanket.lightning_broadcast_radius.description": "How far in blocks players will receive lightning strikes from in-game. Set to 0 to effectively disable broadcasting.",
 	"gamerule.fireblanket.adventure_wind_charge_interaction": "Wind charges interaction in Adventure",
 	"gamerule.fireblanket.adventure_wind_charge_interaction.description": "Whether wind charges interact with blocks in adventure.",
+	"gamerule.fireblanket.allow_trigger_explosions": "Allow trigger explosions",
+	"gamerule.fireblanket.allow_trigger_explosions.description": "Whether trigger explosions (such as those from wind charges) can happen",
 	"commands.gamerule.locked": "You do not have permission to modify this gamerule",
 	"commandsBlock.commandSetByPlayer": "%s set the command at (%s) to: %s",
 	"fireblanket.fsc.broken": "[Fireblanket] Despite relevant mixins being disabled or broken, we're still requesting FSC?",


### PR DESCRIPTION
Question is if we even want to keep the previous gamerule?
With previous gamerule (as long as the chunks are loaded) you can just disconnect to trigger blocks anyways